### PR TITLE
Added empty options for select

### DIFF
--- a/app/Orchid/Screens/FilterExample.php
+++ b/app/Orchid/Screens/FilterExample.php
@@ -56,6 +56,7 @@ class FilterExample extends Screen
 
                 TD::make('is_private', 'Private')
                     ->filter(Select::make()
+                        ->empty()
                         ->options([
                             'yes' => 'Yes',
                             'no' => 'No',
@@ -65,6 +66,7 @@ class FilterExample extends Screen
 
                 TD::make('show', 'Show')
                     ->filter(Select::make()
+                        ->empty()
                         ->options([
                             'yes' => 'Yes',
                             'no' => 'No',


### PR DESCRIPTION
This adds an empty (unselected) value to the `<select>` filter.  

In HTML, the `<select>` element doesn’t have a built-in empty state—by default, the first option is always selected. Here’s a demonstration of this behavior: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select

To work around this, it's common to add an empty `<option>`, like in the example above:  

```html
<option value="">--Please choose an option--</option>
```  

In your code, this was missing, so a value was selected automatically.